### PR TITLE
Improve terminal layout and styling

### DIFF
--- a/src/components/Chatbot.tsx
+++ b/src/components/Chatbot.tsx
@@ -311,15 +311,19 @@ export default function Chatbot({ initialContent }: ChatbotProps) {
             border: 1px solid #9fe0b3;
             padding: 0.5rem;
             background: #111;
+            text-align: left;
           }
-          .console {
-            display: flex;
-            flex-direction: column;
-            max-height: 400px;
-            overflow-y: scroll;
-            scrollbar-width: none;
-            -ms-overflow-style: none;
-          }
+            .console {
+              display: flex;
+              flex-direction: column;
+              max-height: 400px;
+              overflow-y: scroll;
+              scrollbar-width: none;
+              -ms-overflow-style: none;
+              font-family: 'Courier New', Courier, monospace;
+              text-align: left;
+              white-space: pre-wrap;
+            }
           .console::-webkit-scrollbar {
             display: none;
           }
@@ -356,20 +360,9 @@ export default function Chatbot({ initialContent }: ChatbotProps) {
               ))}
             </ul>
           </div>
-          <div className="module vessel">
-            <h2>ATHANOR--</h2>
-            <p>Empty.</p>
-          </div>
         </div>
         <div className="center-column" style={{ display: 'flex', flexDirection: 'column', gap: '1rem', alignItems: 'center' }}>
-          <div className="module">
-            <HexExits
-              lexDefs={lexDefs}
-              entranceLink={bookBindle.length > 1 ? bookBindle[bookBindle.length - 2]?.title : ""}
-              exitLink={links[0] || ""}
-            />
-          </div>
-          <div className="module console">
+          <div className="module console" style={{ textAlign: 'left' }}>
             {typedConsole.map((line, i) => (
               <div key={i}>
                 <code>&gt; {line}</code>
@@ -426,19 +419,7 @@ export default function Chatbot({ initialContent }: ChatbotProps) {
               </form>
             </div>
           </div>
-        </div>
-        <div className="side">
-          <div className="module stats">
-            <p><strong>Co-Ordinate:</strong>{' '}
-              <a href={coordinate} target="_blank" rel="noopener noreferrer">
-                {displayCoordinate(coordinate)}
-              </a>
-            </p>
-            <p><strong>Iteration:</strong> {iteration}</p>
-            <p><strong>Learned Spells:</strong> {spells.join(', ')}</p>
-            <p><strong>lexDefs:</strong> {lexDefs.join('; ') || 'None yet'}</p>
-          </div>
-          <div className="module book-details">
+          <div className="module book-details" style={{ textAlign: 'left' }}>
             <h2>Current Book Held, Close||Open</h2>
             {lastBook ? (
               <>
@@ -463,6 +444,24 @@ export default function Chatbot({ initialContent }: ChatbotProps) {
                 </div>
               </div>
             )}
+          </div>
+        </div>
+        <div className="side">
+          <div className="module stats">
+            <p><strong>Co-Ordinate:</strong>{' '}
+              <a href={coordinate} target="_blank" rel="noopener noreferrer">
+                {displayCoordinate(coordinate)}
+              </a>
+            </p>
+            <p><strong>Iteration:</strong> {iteration}</p>
+            <p><strong>lexDefs:</strong> {lexDefs.join('; ') || 'None yet'}</p>
+          </div>
+          <div className="module">
+            <HexExits
+              lexDefs={lexDefs}
+              entranceLink={bookBindle.length > 1 ? bookBindle[bookBindle.length - 2]?.title : ""}
+              exitLink={links[0] || ""}
+            />
           </div>
         </div>
       </div>

--- a/src/components/HexExits.tsx
+++ b/src/components/HexExits.tsx
@@ -16,7 +16,7 @@ const HexExits = ({ lexDefs, entranceLink, exitLink }: HexExitsProps) => {
     const ctx = canvas.getContext("2d");
     if (!ctx) return;
 
-    const hexSize = 90;
+    const hexSize = 45;
     const hexHeight = Math.sqrt(3) * hexSize;
     const hexWidth = 2 * hexSize;
 
@@ -118,16 +118,16 @@ const HexExits = ({ lexDefs, entranceLink, exitLink }: HexExitsProps) => {
   return (
     <div
       style={{
-        width: '800px',
-        height: '600px',
+        width: '400px',
+        height: '300px',
         overflow: 'hidden',
         margin: '2rem auto'
       }}
     >
-      <canvas
-        ref={canvasRef}
-        width={800}
-        height={600}
+        <canvas
+          ref={canvasRef}
+          width={400}
+          height={300}
         style={{
           display: "block",
           background: "#000000",


### PR DESCRIPTION
## Summary
- shrink `HexExits` graphics
- restyle console and module sections for a retro look
- move `HexExits` to side panel
- center book details below terminal input
- remove unused ATHANOR section and learned spell list
- fix mismatched closing tag in Chatbot layout

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ff6f477e4833290e5da576f181d83